### PR TITLE
Fixes filter query with empty barcode

### DIFF
--- a/app/search_builders/phydo/catalog_search_builder.rb
+++ b/app/search_builders/phydo/catalog_search_builder.rb
@@ -59,7 +59,7 @@ module Phydo
 
       def barcode_filter
         @barcode_filter ||=
-          if blacklight_params['barcode']
+          unless blacklight_params['barcode'].blank?
             'barcode_ssim:' + blacklight_params['barcode']
           end
       end

--- a/spec/search_builders/phydo/catalog_search_builder_spec.rb
+++ b/spec/search_builders/phydo/catalog_search_builder_spec.rb
@@ -23,9 +23,16 @@ RSpec.describe Phydo::CatalogSearchBuilder do
         'action' => 'index',
         'barcode' => '123456') }
 
+    let(:params_empty_barcode) { ActionController::Parameters.new(
+        'controller' => 'catalog',
+        'action' => 'index',
+        'barcode' => '') }
+
     let(:builder_with_barcode) { described_class.new(scope).with(params_with_barcode) }
 
     let(:builder_no_barcode) { described_class.new(scope).with(params) }
+
+    let(:builder_empty_barcode) { described_class.new(scope).with(params_empty_barcode) }
 
     context 'when there is a barcode in params' do
       subject { builder_with_barcode.query }
@@ -39,7 +46,15 @@ RSpec.describe Phydo::CatalogSearchBuilder do
       subject { builder_no_barcode.query }
 
       it 'does not filter for barcode when not in params' do
-        expect(subject[:fq]).not_to include('barcode_ssim:123456')
+        expect(subject[:fq]).not_to include('barcode_ssim:')
+      end
+    end
+
+    context 'when there is an empty barcode in params' do
+      subject { builder_empty_barcode.query }
+
+      it 'does not filter for barcode when not in params' do
+        expect(subject[:fq]).not_to include('barcode_ssim:')
       end
     end
   end


### PR DESCRIPTION
@afred - in working on the other filter ticket i realized that the barcode filter query would break if submitted empty. checked how this was handled elsewhere, so now it returns all if left blank and submitted.