### PR TITLE
[HDM-1152] Add search filter for Filename

### DIFF
--- a/app/search_builders/phydo/catalog_search_builder.rb
+++ b/app/search_builders/phydo/catalog_search_builder.rb
@@ -3,7 +3,8 @@ module Phydo
 
     self.default_processor_chain += [
       :apply_last_fixity_date_time_filter,
-      :apply_barcode_filter
+      :apply_barcode_filter,
+      :apply_filename_filter
     ]
 
     def models
@@ -22,6 +23,14 @@ module Phydo
       if barcode_filter
         solr_params[:fq] ||= []
         solr_params[:fq] << barcode_filter
+      end
+      solr_params
+    end
+
+    def apply_filename_filter(solr_params)
+      if filename_filter
+        solr_params[:fq] ||= []
+        solr_params[:fq] << filename_filter
       end
       solr_params
     end
@@ -61,6 +70,13 @@ module Phydo
         @barcode_filter ||=
           unless blacklight_params['barcode'].blank?
             'barcode_ssim:' + blacklight_params['barcode']
+          end
+      end
+
+      def filename_filter
+        @filename_filter ||=
+          unless blacklight_params['filename'].blank?
+            'label_tesim:' + blacklight_params['filename']
           end
       end
   end

--- a/app/views/filter_search/_filename.html.erb
+++ b/app/views/filter_search/_filename.html.erb
@@ -1,0 +1,19 @@
+<h2>Filename</h2>
+<%
+# TODO: use URL helper instead of hardcoded "/catalog"?
+%>
+<form id="filename_filter" action="/catalog">
+  <label>Filename</label>
+  <input name="filename" type="text" value="<%= params['filename'] %>" /><br />
+
+  <!-- TODO: This logic needs to be replicated for all filter forms. Better in a helper method? -->
+  <% Rack::Utils.parse_query(request.query_string).except("filename").each do |param, val| %>
+    <% # Sometimes `val` may be an array, but not always. So we just array-ify
+       # it here to cover both cases. %>
+    <% Array(val).each do |single_val| %>
+      <input type="hidden" name="<%= param %>" value="<%= single_val %>" />
+    <% end %>
+  <% end %>
+
+  <button type="submit" class="btn btn-primary">Submit</button>
+</form>

--- a/app/views/shared/_filter_search.html.erb
+++ b/app/views/shared/_filter_search.html.erb
@@ -4,3 +4,4 @@
 <%= render 'filter_search/ingest_date_time' %>
 <%= render 'filter_search/last_fixity_date_time' %>
 <%= render 'filter_search/barcode' %>
+<%= render 'filter_search/filename' %>

--- a/spec/search_builders/phydo/catalog_search_builder_spec.rb
+++ b/spec/search_builders/phydo/catalog_search_builder_spec.rb
@@ -58,4 +58,51 @@ RSpec.describe Phydo::CatalogSearchBuilder do
       end
     end
   end
+
+  describe '.apply_filename_filter' do
+    let(:params) { ActionController::Parameters.new(
+        'controller' => 'catalog',
+        'action' => 'index') }
+
+    let(:params_with_filename) { ActionController::Parameters.new(
+        'controller' => 'catalog',
+        'action' => 'index',
+        'filename' => 'test_file.xml') }
+
+    let(:params_empty_filename) { ActionController::Parameters.new(
+        'controller' => 'catalog',
+        'action' => 'index',
+        'filename' => '') }
+
+    let(:builder_with_filename) { described_class.new(scope).with(params_with_filename) }
+
+    let(:builder_no_filename) { described_class.new(scope).with(params) }
+
+    let(:builder_empty_filename) { described_class.new(scope).with(params_empty_filename) }
+
+    context 'when there is a filename in params' do
+      subject { builder_with_filename.query }
+
+      it 'filters for filename when present in params' do
+        expect(subject[:fq]).to include('label_tesim:test_file.xml')
+      end
+    end
+
+    context 'when there is no filename in params' do
+      subject { builder_no_filename.query }
+
+      it 'does not filter for filename when not in params' do
+        expect(subject[:fq]).not_to include('label_tesim:')
+      end
+    end
+
+    context 'when there is an empty filename in params' do
+      subject { builder_empty_filename.query }
+
+      it 'does not filter for filename when not in params' do
+        expect(subject[:fq]).not_to include('label_tesim:')
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
@jasoncorum @afred This is implemented to search on the `label`, but I'm not certain in the WGBH case if that, or `title`, or `filename` is the most appropriate field -- in the IU case, `filename` contains the full path.

An alternative approach to this entire thing would be to allow a partial match on the file_path search implemented in https://github.com/WGBH/phydo/pull/22

Pushed feature branch to IUBLibTech/phydo as I seem to lack permissions for WGBH/phydo