### PR TITLE
HDM-1202: file_name filter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,9 @@ gem 'blacklight_range_limit', github: 'projectblacklight/blacklight_range_limit'
 gem 'hyrax-ingest', github: 'IUBLibTech/hyrax-ingest', branch: 'master'
 gem 'hyrax-preservation', github: 'IUBLibTech/hyrax-preservation', branch: 'master'
 
+# Pin rdf-vocab to 2.2.8 since 2.2.9 introduced breaking changes
+gem 'rdf-vocab', '2.2.8'
+
 # CC v2.0.0 seems to not include BL advanced search anymore?
 gem 'blacklight_advanced_search', '~> 6.2.1'
 gem 'rsolr', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 
 GIT
   remote: git://github.com/projectblacklight/blacklight_range_limit.git
-  revision: f1cb424f431055fdf85facdf30bc37f3f4386bfe
+  revision: 2d5956e3230df86a8df33b84749bb0f91ef739df
   branch: master
   specs:
     blacklight_range_limit (6.3.1)
@@ -108,8 +108,8 @@ GEM
       execjs
     awesome_nested_set (3.1.3)
       activerecord (>= 4.0.0, < 5.2)
-    aws-partitions (1.49.0)
-    aws-sdk-core (3.11.0)
+    aws-partitions (1.51.0)
+    aws-sdk-core (3.12.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
@@ -325,7 +325,7 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     hashdiff (0.3.7)
-    hashie (3.5.6)
+    hashie (3.5.7)
     hiredis (0.6.1)
     htmlentities (4.3.4)
     http_logger (0.5.1)
@@ -681,8 +681,8 @@ GEM
     rdf-turtle (2.2.2)
       ebnf (~> 1.1)
       rdf (>= 2.2, < 4.0)
-    rdf-vocab (2.2.9)
-      rdf (>= 2.2, < 4.0)
+    rdf-vocab (2.2.8)
+      rdf (~> 2.2)
     rdf-xsd (2.2.1)
       rdf (>= 2.2, < 4.0)
     rdoc (4.3.0)
@@ -900,6 +900,7 @@ DEPENDENCIES
   rails (~> 5.0.0, >= 5.0.0.1)
   rails-controller-testing
   rb-readline
+  rdf-vocab (= 2.2.8)
   rsolr (~> 1.0)
   rspec-rails
   rubocop (~> 0.49)

--- a/app/search_builders/phydo/catalog_search_builder.rb
+++ b/app/search_builders/phydo/catalog_search_builder.rb
@@ -76,7 +76,7 @@ module Phydo
       def filename_filter
         @filename_filter ||=
           unless blacklight_params['filename'].blank?
-            'label_tesim:' + blacklight_params['filename']
+            "file_name_tesim:" + "\"#{blacklight_params['filename']}\""
           end
       end
   end

--- a/spec/search_builders/phydo/catalog_search_builder_spec.rb
+++ b/spec/search_builders/phydo/catalog_search_builder_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Phydo::CatalogSearchBuilder do
       subject { builder_with_filename.query }
 
       it 'filters for filename when present in params' do
-        expect(subject[:fq]).to include('label_tesim:test_file.xml')
+        expect(subject[:fq]).to include("file_name_tesim:\"test_file.xml\"")
       end
     end
 
@@ -92,7 +92,7 @@ RSpec.describe Phydo::CatalogSearchBuilder do
       subject { builder_no_filename.query }
 
       it 'does not filter for filename when not in params' do
-        expect(subject[:fq]).not_to include('label_tesim:')
+        expect(subject[:fq]).not_to include('file_name_tesim:')
       end
     end
 
@@ -100,7 +100,7 @@ RSpec.describe Phydo::CatalogSearchBuilder do
       subject { builder_empty_filename.query }
 
       it 'does not filter for filename when not in params' do
-        expect(subject[:fq]).not_to include('label_tesim:')
+        expect(subject[:fq]).not_to include('file_name_tesim:')
       end
     end
   end


### PR DESCRIPTION
Updates the file_name filter to use the file_name attribute (instead of label) and uses quotes in the filter to limit inclusion so that files with the same extensions are not included in the filter.